### PR TITLE
[Breaking] Change chunk.modules.map to chunk.mapModules for Webpack 3 support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function MD5HashPlugin () {
 MD5HashPlugin.prototype.apply = function(compiler) {
     compiler.plugin("compilation", function(compilation) {
         compilation.plugin("chunk-hash", function(chunk, chunkHash) {
-            var source = chunkIdSource(chunk) + chunk.modules.map(getModuleSource).sort(compareModules).reduce(concatenateSource, ''); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
+            var source = chunkIdSource(chunk) + chunk.mapModules(getModuleSource).sort(compareModules).reduce(concatenateSource, ''); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
             var chunk_hash = md5(source);
             chunkHash.digest = function () {
                 return chunk_hash;


### PR DESCRIPTION
Breaking change - will not support Webpack < 3.

Resolves #1 